### PR TITLE
Acertos no arquivo de configuração.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,9 +1,9 @@
 baseurl = "http://localhost"
 title = "OsProgramadores"
 theme = "hugo-universal-theme"
-languageCode = "pt-br"
+languageCode = "en-us"
 # Site language. Available translations in the theme's `/i18n` directory.
-defaultContentLanguage = "pt"
+defaultContentLanguage = "en"
 # Enable comments by entering your Disqus shortname
 # disqusShortname = "devcows"
 # Enable Google Analytics by entering your tracking code
@@ -20,8 +20,8 @@ paginate = 10
     weight = 1
 
 [[menu.main]]
-    name = "Artigos"
-    url  = "/artigos/"
+    name = "Blog"
+    url  = "/blog/"
     weight = 2
 
 [[menu.main]]
@@ -38,12 +38,12 @@ paginate = 10
     viewMorePostLink = "/blog/"
     author = "mpinheir"
     defaultKeywords = ["programacao", "programas", "coding"]
-    defaultDescription = "Template criado por osprogramadores usando o hugo"
+    defaultDescription = "Template criado por osprogramadores usando hugo e o tema Universal."
 
     # Google Maps API key (if not set will default to not passing a key.)
     googleMapsApiKey = ""
 
-    # Style options: default (light-blue), blue, green, marsala, pink, red, turquoise, violet
+    # Style options: default (light-blue), blue, green, marsala, pink, red, turquoise, violet
     style = "default"
 
     # Since this template is static, the contact form uses www.formspree.io as a
@@ -88,7 +88,7 @@ paginate = 10
     # For more informtion take a look at the README.
 
 [params.features]
-    enable = true
+    enable = false
     # All features are defined in their own files. You can find example items
     # at 'exampleSite/data/features'.
     # For more informtion take a look at the README.


### PR DESCRIPTION
- Linguagem temporariamente modificada pra en-us. É necessario
  criar um arquivo de tradução antes de modificar a linguagem.
- "Artigos" modificado para "Blog". Por alguma razão, arquivos
  markdown embaixo de content/artigos não produziam saída.
- Modificada a descrição default do site.
- "Features" desabilitadas (evita mensagem de erro na renderização)